### PR TITLE
Slim down travis testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ ENV/
 
 # Mac
 .DS_Store
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,7 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pandas networkx pytest pytest-cov
-  - source activate test-environment
-  - python setup.py install
+  - pip install .
 script: py.test -s
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - pip install .
-script: py.test -s
+script: python -m pytest
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
+  - pip install pytest
   - pip install .
 script: python -m pytest
 branches:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include postman_problems/examples/sleeping_giant/edgelist_sleeping_giant.csv
 include postman_problems/examples/sleeping_giant/nodelist_sleeping_giant.csv
 include postman_problems/examples/seven_bridges/edgelist_seven_bridges.csv
-include postman_problems/examples/seven_bridges/nodelist_seven_bridges.csv

--- a/setup.py
+++ b/setup.py
@@ -13,18 +13,6 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-class build_ext(_build_ext):
-    """
-    Hack needed to build numpy properly
-    See: https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py
-    """
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
-
 setup(
     name='postman_problems',
     version='0.1dev',
@@ -50,8 +38,6 @@ setup(
         'console_scripts': ['chinese_postman=postman_problems.chinese_postman:main']
     },
     python_requires='>=3.5',
-    cmdclass={'build_ext':build_ext},
-    setup_requires='numpy',
     install_requires=[
         'pandas',
         'networkx',

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,29 @@
 import os
 from setuptools import setup
-
-# Utility function to read the README file.
-# Used for the long_description.  It's nice, because now 1) we have a top level
-# README file and 2) it's easier to type in the README file than to put a raw
-# string in below ...
+from setuptools.command.build_ext import build_ext as _build_ext
 
 
 def read(fname):
+    """
+    Utility function to read the README file.
+    Used for the long_description.  It's nice, because now 1) we have a top level
+    README file and 2) it's easier to type in the README file than to put a raw
+    string in below ...
+    """
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+class build_ext(_build_ext):
+    """
+    Hack needed to build numpy properly
+    See: https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py
+    """
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
 setup(
     name='postman_problems',
@@ -35,6 +50,8 @@ setup(
         'console_scripts': ['chinese_postman=postman_problems.chinese_postman:main']
     },
     python_requires='>=3.5',
+    cmdclass={'build_ext':build_ext},
+    setup_requires='numpy',
     install_requires=[
         'pandas',
         'networkx',


### PR DESCRIPTION
Use `pip install .` instead of `python setup.py install` in TravisCI to avoid numpy/pandas install issues documented here: https://stackoverflow.com/questions/25753276/install-numpy-pandas-as-dependency-in-setup-py

Slimming down Travis build to use the dependencies directly from postman_problems install (rather than creating a separate test conda environment which needs dependencies listed separately).

