### PR TITLE
tighten read_edgelist

### DIFF
--- a/postman_problems/graph.py
+++ b/postman_problems/graph.py
@@ -14,7 +14,7 @@ def read_edgelist(edgelist_filename, keep_optional=False):
         pandas dataframe of edgelist
     """
     el = pd.read_csv(edgelist_filename, dtype={0: str, 1: str})  # node_ids as strings makes life easier
-    el = el.dropna()  # drop rows with all NAs... as I find CSVs created w Numbers annoyingly do.
+    el = el.dropna(how='all')  # drop rows with all NAs... as I find CSVs created w Numbers annoyingly do.
 
     if (not keep_optional) & ('required' in el.columns):
         el = el[el['required'] == 1]

--- a/postman_problems/graph.py
+++ b/postman_problems/graph.py
@@ -1,6 +1,7 @@
 import warnings
 import networkx as nx
 import pandas as pd
+import io
 
 
 def read_edgelist(edgelist_filename, keep_optional=False):
@@ -13,7 +14,7 @@ def read_edgelist(edgelist_filename, keep_optional=False):
     Returns:
         pandas dataframe of edgelist
     """
-    el = pd.read_csv(edgelist_filename)
+    el = pd.read_csv(edgelist_filename, dtype={0: str, 1: str})  # node_ids as strings makes life easier
     el = el.dropna()  # drop rows with all NAs... as I find CSVs created w Numbers annoyingly do.
 
     if (not keep_optional) & ('required' in el.columns):

--- a/postman_problems/graph.py
+++ b/postman_problems/graph.py
@@ -1,7 +1,6 @@
 import warnings
 import networkx as nx
 import pandas as pd
-import io
 
 
 def read_edgelist(edgelist_filename, keep_optional=False):


### PR DESCRIPTION
tightening read_edgelist function to:
 - only remove rows that are all NA (previously dropped any row with any NA... including attributes.. oops)
 - read first two columns (node ids) as strings to ensure smoother computation