### PR TITLE
keep generators rather than converting to lists

### DIFF
--- a/postman_problems/solver.py
+++ b/postman_problems/solver.py
@@ -44,7 +44,7 @@ def rpp(edgelist_filename, start_node=None, edge_weight='distance', verbose=Fals
 
     logger_rpp.info('getting odd node pairs')
     odd_nodes = get_odd_nodes(g_req)
-    odd_node_pairs = list(itertools.combinations(odd_nodes, 2))
+    odd_node_pairs = itertools.combinations(odd_nodes, 2)
 
     logger_rpp.info('get shortest paths between odd nodes')
     odd_node_pairs_shortest_paths = get_shortest_paths_distances(g_full, odd_node_pairs, edge_weight)
@@ -89,7 +89,7 @@ def cpp(edgelist_filename, start_node=None, edge_weight='distance', verbose=Fals
 
     logger_cpp.info('get augmenting path for odd nodes')
     odd_nodes = get_odd_nodes(g)
-    odd_node_pairs = list(itertools.combinations(odd_nodes, 2))
+    odd_node_pairs = itertools.combinations(odd_nodes, 2)
     odd_node_pairs_shortest_paths = get_shortest_paths_distances(g, odd_node_pairs, edge_weight)
     g_odd_complete = create_complete_graph(odd_node_pairs_shortest_paths, flip_weights=True)
 


### PR DESCRIPTION
@brooksandrew For large graphs the conversion to lists for combinations causes "memory error" exceptions, this can be mitigated by using the generator object directly.
